### PR TITLE
Pre-define variables to satisfy Wesnoth strict mode

### DIFF
--- a/8680s_Lua_Pack/_load.lua
+++ b/8680s_Lua_Pack/_load.lua
@@ -1,21 +1,22 @@
 
 -- By 8680.
 
-if not namespace_of_8680s_Lua_Pack then
-	namespace_of_8680s_Lua_Pack = {}
-	lp8 = lp8 == nil and namespace_of_8680s_Lua_Pack or error(
-		"8680s_Lua_Pack initialization aborted: global variable lp8 already taken!", 0)
-	lp8.helper = wesnoth.require "lua/helper.lua"
-	lp8.lp8dir = dir_of_8680s_Lua_Pack
-	function lp8.require(lib)
-		assert(lp8 == namespace_of_8680s_Lua_Pack)
-		local alreadyLoaded = lp8[lib]
-		if not alreadyLoaded then
-			lp8[lib] = wesnoth.require(lp8.lp8dir .. lib .. ".lua")
-		end
-		return lp8[lib], alreadyLoaded
+-- Pre-declare variables to satify Wesnoth strict mode
+lp8 = nil
+namespace_of_8680s_Lua_Pack = {}
+
+lp8 = lp8 == nil and namespace_of_8680s_Lua_Pack or error(
+	"8680s_Lua_Pack initialization aborted: global variable lp8 already taken!", 0)
+lp8.helper = wesnoth.require "lua/helper.lua"
+lp8.lp8dir = dir_of_8680s_Lua_Pack
+function lp8.require(lib)
+	assert(lp8 == namespace_of_8680s_Lua_Pack)
+	local alreadyLoaded = lp8[lib]
+	if not alreadyLoaded then
+		lp8[lib] = wesnoth.require(lp8.lp8dir .. lib .. ".lua")
 	end
-	lp8.require 'load'
+	return lp8[lib], alreadyLoaded
 end
+lp8.require 'load'
 
 return lp8.require


### PR DESCRIPTION
This is a 1.13 feature that attempts to ensure variables are defined before
use in order to catch issues.

Note that I disabled strict mode in SoD since it was causing issues and I couldn't get the 'lp8' variables declared in a global namespace seen by both wesnoth-lp8 and wesnoth. However, this should help other users of lp8 on 1.13.
